### PR TITLE
Fix conda env creation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -140,4 +140,3 @@ dependencies:
       - wcwidth==0.2.13
       - xxhash==3.5.0
       - yarl==1.20.0
-prefix: /home/cmontes/miniconda3/envs/qlora


### PR DESCRIPTION
## Summary
- remove the host-specific `prefix` entry from `environment.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

