### PR TITLE
Improve token check before loading models

### DIFF
--- a/gpu_memory_test.py
+++ b/gpu_memory_test.py
@@ -8,10 +8,15 @@ bnb = BitsAndBytesConfig(
 )
 
 hf_token = os.getenv("HF_TOK")
+if hf_token is None:
+    raise EnvironmentError(
+        "HF_TOK environment variable not set. Please set it to your HuggingFace token "
+        "before running this script."
+    )
 
 tok = AutoTokenizer.from_pretrained(
     "meta-llama/Meta-Llama-3-8B-Instruct",
-    use_auth_token=hf_token  
+    use_auth_token=hf_token
 )
 
 model = AutoModelForCausalLM.from_pretrained(

--- a/train_naive.py
+++ b/train_naive.py
@@ -13,6 +13,11 @@ bnb = BitsAndBytesConfig(
 )
 
 hf_token = os.getenv("HF_TOK")
+if hf_token is None:
+    raise EnvironmentError(
+        "HF_TOK environment variable not set. Please set it to your HuggingFace token "
+        "before running this script."
+    )
 
 tok = AutoTokenizer.from_pretrained(
     "meta-llama/Meta-Llama-3-8B-Instruct",


### PR DESCRIPTION
## Summary
- validate that `HF_TOK` is set before using `AutoTokenizer` in `train_naive.py`
- validate that `HF_TOK` is set before using `AutoTokenizer` in `gpu_memory_test.py`

## Testing
- `python -m py_compile train_naive.py gpu_memory_test.py`

------
https://chatgpt.com/codex/tasks/task_e_683ffb2c28b8832485d97e3f2fefb719