### PR TITLE
Add header comments to scripts

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -1,3 +1,10 @@
+"""Benchmark utility for quantized language models.
+
+This script loads a model (optionally with a LoRA adapter) and reports
+memory usage, generation latency and perplexity metrics for a given
+prompt or dataset. The resulting statistics are written to a JSON file.
+"""
+
 import time
 import torch
 import json

--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,6 @@
+# Conda environment definition for hyperbench-llm
+# Includes PyTorch, Transformers and supporting libraries for running
+# the benchmarking and training scripts.
 name: qlora
 channels:
   - defaults

--- a/gpu_memory_test.py
+++ b/gpu_memory_test.py
@@ -1,3 +1,10 @@
+"""Report the GPU memory footprint of a quantized model.
+
+This helper script loads Llama-3 in 4-bit precision and prints the amount
+of memory consumed on the GPU after loading. It requires a Hugging Face
+token via the ``HF_TOK`` environment variable to download the weights.
+"""
+
 from transformers import AutoTokenizer, AutoModelForCausalLM, BitsAndBytesConfig
 import os
 

--- a/merge_lora.py
+++ b/merge_lora.py
@@ -1,3 +1,10 @@
+"""Merge a LoRA adapter into its base model for inference.
+
+This script loads both the full-precision base model and its LoRA weights,
+combines them into a single set of parameters, and saves the merged model
+to disk. Use this after training to deploy without the PEFT dependency.
+"""
+
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from peft import PeftModel
 import argparse

--- a/qlora_loss.yaml
+++ b/qlora_loss.yaml
@@ -1,3 +1,4 @@
+# Weights & Biases sweep configuration targeting low validation loss
 method: bayes
 metric:
   name: eval_loss

--- a/train_fast.py
+++ b/train_fast.py
@@ -1,4 +1,9 @@
-# Fine-tuning Llama-3 8B with speed-optimal settings for A100 GPU
+"""Fine-tune Llama-3 8B with optimized settings for A100 GPUs.
+
+The script demonstrates a fast LoRA training setup using 4-bit quantization
+and a high batch size. It is intended for quick experimentation on a single
+GPU and saves only the adapter weights after training.
+"""
 
 from transformers import AutoTokenizer, AutoModelForCausalLM, BitsAndBytesConfig
 from transformers import TrainingArguments, Trainer

--- a/train_h100.py
+++ b/train_h100.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
-"""
-Param-sweep-ready LoRA fine-tune for Llama-3 8B on H100 NVL.
+"""Parameter sweep training script targeting H100 GPUs.
 
-Every tunable hyper-parameter is exposed on the CLI so that
-WandB’s sweep agent can drive the grid / Bayesian search.
+The goal of this script is to expose every relevant hyper-parameter on
+the command line so that Weights & Biases can orchestrate a sweep over
+the search space. It performs LoRA fine-tuning of Llama-3 8B and logs
+token throughput and loss metrics during training.
 """
 
 import argparse, os, torch

--- a/train_naive.py
+++ b/train_naive.py
@@ -1,8 +1,15 @@
+"""Simple LoRA fine-tuning example for smaller GPUs.
+
+This script demonstrates a minimal training loop using 4-bit quantization
+and LoRA adapters. It is intended as a starting point for experiments and
+logs basic training metrics using the Hugging Face Trainer API.
+"""
+
 from transformers import AutoTokenizer, AutoModelForCausalLM, BitsAndBytesConfig
-from transformers import TrainingArguments, Trainer  
-from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training   
-from datasets import load_dataset            
-import torch                                      
+from transformers import TrainingArguments, Trainer
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+from datasets import load_dataset
+import torch
 import os
 
 # load 4 bit


### PR DESCRIPTION
## Summary
- add descriptive docstrings to each Python training/utility script
- comment environment files and W&B sweep config

## Testing
- `python -m py_compile bench.py gpu_memory_test.py merge_lora.py train_fast.py train_h100.py train_naive.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

